### PR TITLE
Add .rules for mcp-server-byterover and update README with context server source

### DIFF
--- a/.rules
+++ b/.rules
@@ -1,0 +1,4 @@
+[mcp-server-byterover]
+# important
+always use search-memories tool to get the related context before any tasks
+always use create-memories to store all the critical informations after sucessfull tasks

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To use the extension, you will need to config the context server by setting the 
   "context_servers": {
     "mcp-server-byterover": {
       "settings": {
+        "source": "extension",
         "memory_workspace_key": "MEMORY_WORKSPACE_KEY",
         "user_email": "YOUR_EMAIL"
       }


### PR DESCRIPTION
Add .rules for mcp-server-byterover and update README with context server source

- Introduce a .rules file specifying memory search and storage requirements for mcp-server-byterover.
- Update README to include the source field in the context server configuration example.